### PR TITLE
Ensure We're Not Trying To Repersist Things When We Initialize

### DIFF
--- a/lib/shopify_api/app_server.ex
+++ b/lib/shopify_api/app_server.ex
@@ -20,10 +20,22 @@ defmodule ShopifyAPI.AppServer do
   @spec set(App.t()) :: :ok
   def set(%App{name: name} = app), do: set(name, app)
 
+  @spec set(App.t(), false) :: :ok
+  def set(%App{name: name} = app, false), do: set(name, app, false)
+
   @spec set(String.t(), App.t()) :: :ok
-  def set(name, %App{} = app) do
+  def set(name, %App{} = app), do: set(name, app, true)
+
+  @spec set(String.t(), App.t(), true) :: :ok
+  def set(name, %App{} = app, true) do
     :ets.insert(@table, {name, app})
     do_persist(app)
+    :ok
+  end
+
+  @spec set(String.t(), App.t(), false) :: :ok
+  def set(name, %App{} = app, false) do
+    :ets.insert(@table, {name, app})
     :ok
   end
 
@@ -44,7 +56,7 @@ defmodule ShopifyAPI.AppServer do
   @impl GenServer
   def init(:ok) do
     create_table!()
-    for %App{} = app <- do_initialize(), do: set(app)
+    for %App{} = app <- do_initialize(), do: set(app, false)
     {:ok, :no_state}
   end
 

--- a/lib/shopify_api/shop_server.ex
+++ b/lib/shopify_api/shop_server.ex
@@ -18,9 +18,9 @@ defmodule ShopifyAPI.ShopServer do
   def count, do: :ets.info(@table, :size)
 
   @spec set(Shop.t()) :: :ok
-  def set(%Shop{domain: domain} = shop) do
+  def set(%Shop{domain: domain} = shop, persist? \\ true) do
     :ets.insert(@table, {domain, shop})
-    do_persist(shop)
+    if persist?, do: do_persist(shop)
     :ok
   end
 
@@ -41,7 +41,7 @@ defmodule ShopifyAPI.ShopServer do
   @impl GenServer
   def init(:ok) do
     create_table!()
-    for %Shop{} = shop <- do_initialize(), do: set(shop)
+    for %Shop{} = shop <- do_initialize(), do: set(shop, false)
     {:ok, :no_state}
   end
 


### PR DESCRIPTION
Modification attempts to ensure that persistence callbacks are not
called upon initialization of ETS tables.